### PR TITLE
Added default support for object serialization

### DIFF
--- a/src/LightResults.Extensions.Json/ResultJsonConverter.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverter.cs
@@ -158,6 +158,10 @@ public sealed class ResultJsonConverter : JsonConverter<Result>
             case ulong value:
                 writer.WriteNumber(name, value);
                 break;
+            default:
+                writer.WritePropertyName(name);
+                JsonSerializer.Serialize(writer, obj, obj.GetType());
+                break;
         }
     }
 

--- a/src/LightResults.Extensions.Json/ResultJsonConverter`1.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverter`1.cs
@@ -162,6 +162,10 @@ public sealed class ResultJsonConverter<TValue> : JsonConverter<Result<TValue>>
             case ulong value:
                 writer.WriteNumber(name, value);
                 break;
+            default:
+                writer.WritePropertyName(name);
+                JsonSerializer.Serialize(writer, obj, obj.GetType());
+                break;
         }
     }
 

--- a/tests/LightResults.Extensions.Tests/ResultJsonConverterTests.cs
+++ b/tests/LightResults.Extensions.Tests/ResultJsonConverterTests.cs
@@ -36,6 +36,19 @@ public sealed class ResultJsonConverterTests
     }
 
     [Fact]
+    public void SuccessWithObjectValueResult()
+    {
+        // Arrange
+        var result = Result.Ok(new { Id = 1, Name = "Test" });
+
+        // Act
+        var json = JsonSerializer.Serialize(result, Options);
+
+        // Assert
+        json.Should().Be("{\"IsSuccess\":true,\"Value\":{\"Id\":1,\"Name\":\"Test\"}}");
+    }
+
+    [Fact]
     public void FailedResultWithSingleError()
     {
         // Arrange

--- a/tests/LightResults.Extensions.Tests/ResultJsonConverterTests.cs
+++ b/tests/LightResults.Extensions.Tests/ResultJsonConverterTests.cs
@@ -39,7 +39,7 @@ public sealed class ResultJsonConverterTests
     public void SuccessWithObjectValueResult()
     {
         // Arrange
-        var result = Result.Ok(new { Id = 1, Name = "Test" });
+        var result = Result.Success(new { Id = 1, Name = "Test" });
 
         // Act
         var json = JsonSerializer.Serialize(result, Options);


### PR DESCRIPTION
To support serialization for `Result<T>` where `T` is an object, added a default in the switch block.

Added an associated test as well.