### PR TITLE
Fix Collect<TValue> for empty enumerables

### DIFF
--- a/src/LightResults.Extensions.Operations/EnumerableExtensions.cs
+++ b/src/LightResults.Extensions.Operations/EnumerableExtensions.cs
@@ -104,9 +104,14 @@ public static class EnumerableExtensions
             }
         }
         
+        if (errors is null)
+            values ??= [];
+
         Debug.Assert(errors is { Count: > 0 } || values is not null);
-        
-        return errors is { Count: > 0 } ? Result.Failure<IReadOnlyList<TValue>>(errors.AsReadOnly()) : Result.Success<IReadOnlyList<TValue>>(values!.AsReadOnly());
+
+        return errors is { Count: > 0 }
+            ? Result.Failure<IReadOnlyList<TValue>>(errors.AsReadOnly())
+            : Result.Success<IReadOnlyList<TValue>>(values!.AsReadOnly());
     }
 
     /// <summary>Combine multiple results into a single result.</summary>
@@ -144,8 +149,13 @@ public static class EnumerableExtensions
             }
         }
         
+        if (errors is null)
+            values ??= [];
+
         Debug.Assert(errors is { Count: > 0 } || values is not null);
-        
-        return errors is { Count: > 0 } ? Result.Failure<IReadOnlyList<TValue>>(errors.AsReadOnly()) : Result.Success<IReadOnlyList<TValue>>(values!.AsReadOnly());
+
+        return errors is { Count: > 0 }
+            ? Result.Failure<IReadOnlyList<TValue>>(errors.AsReadOnly())
+            : Result.Success<IReadOnlyList<TValue>>(values!.AsReadOnly());
     }
 }

--- a/tests/LightResults.Extensions.Operations.Tests/EnumerableExtensionsTests.cs
+++ b/tests/LightResults.Extensions.Operations.Tests/EnumerableExtensionsTests.cs
@@ -85,4 +85,32 @@ public sealed class EnumerableExtensionsTests
         result.Errors.Count.ShouldBe(2);
         result.Errors.ShouldBe([error, error2], ignoreOrder: true);
     }
+
+    [Fact]
+    public void CollectTValue_WhenResultsAreEmpty_ShouldReturnOkResultWithEmptyValues()
+    {
+        // Arrange
+        var results = Array.Empty<Result<int>>();
+
+        // Act
+        var result = results.Collect();
+
+        // Assert
+        result.IsSuccess(out var values).ShouldBeTrue();
+        values!.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CollectTValue_WhenResultsListIsEmpty_ShouldReturnOkResultWithEmptyValues()
+    {
+        // Arrange
+        IReadOnlyList<Result<int>> results = new List<Result<int>>();
+
+        // Act
+        var result = results.Collect();
+
+        // Assert
+        result.IsSuccess(out var values).ShouldBeTrue();
+        values!.Count.ShouldBe(0);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid null reference when Collect<T> is used on empty collections
- test generic Collect on empty enumerables and lists

## Testing
- `dotnet test tests/LightResults.Extensions.Operations.Tests/LightResults.Extensions.Operations.Tests.csproj -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0`

------
https://chatgpt.com/codex/tasks/task_e_687d3e93f1c08328a6e7c5ef715c92f8