### PR TITLE
Fix Json converter serialization fallback

### DIFF
--- a/src/LightResults.Extensions.Json/LightResults.Extensions.Json.csproj
+++ b/src/LightResults.Extensions.Json/LightResults.Extensions.Json.csproj
@@ -53,9 +53,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\Icon.png" Pack="true" PackagePath="\" Visible="false"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\Icon.png" Pack="true" PackagePath="" Visible="false"/>
     </ItemGroup>
 
     <!-- Testing -->

--- a/src/LightResults.Extensions.Json/ResultJsonConverter.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverter.cs
@@ -179,6 +179,10 @@ public sealed class ResultJsonConverter : JsonConverter<Result>
             case ulong value:
                 writer.WriteNumber(name, value);
                 break;
+            default:
+                writer.WritePropertyName(name);
+                JsonSerializer.Serialize(writer, obj, obj.GetType());
+                break;
         }
     }
 

--- a/src/LightResults.Extensions.Json/ResultJsonConverter`1.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverter`1.cs
@@ -182,6 +182,10 @@ public sealed class ResultJsonConverter<TValue> : JsonConverter<Result<TValue>>
             case ulong value:
                 writer.WriteNumber(name, value);
                 break;
+            default:
+                writer.WritePropertyName(name);
+                JsonSerializer.Serialize(writer, obj, obj.GetType());
+                break;
         }
     }
 


### PR DESCRIPTION
## Summary
- fallback to `JsonSerializer.Serialize` for unsupported values in ResultJsonConverter
- pack docs from project root for `LightResults.Extensions.Json`

## Testing
- `dotnet test tests/LightResults.Extensions.Tests/LightResults.Extensions.Tests.csproj -f net8.0 -v minimal`
- `dotnet test tests/LightResults.Extensions.Operations.Tests/LightResults.Extensions.Operations.Tests.csproj -f net8.0 -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687d3e863ffc832897363663124d8473