### PR TITLE
Fix csproj package path and add formatting files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 240
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 end_of_line = lf
 insert_final_newline = true
-max_line_length = 240
+max_line_length = 160
 
 [*.cs]
 indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+* text=auto eol=lf
+.config text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.cs text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.csproj text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.dist text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.DotSettings text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.editorconfig text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.gitattributes text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.gitignore text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.info text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.js text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.json text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.md text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.ps1 text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.props text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.resx text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.runsettings text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.sln text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.targets text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.txt text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8
+.yml text eol=lf encoding=UTF-8 working-tree-encoding=UTF-8

--- a/src/LightResults.Extensions.EntityFrameworkCore/LightResults.Extensions.EntityFrameworkCore.csproj
+++ b/src/LightResults.Extensions.EntityFrameworkCore/LightResults.Extensions.EntityFrameworkCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <!-- Compilation -->
     <PropertyGroup>
@@ -68,9 +68,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\Icon.png" Pack="true" PackagePath="\" Visible="false"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\Icon.png" Pack="true" PackagePath="" Visible="false"/>
     </ItemGroup>
 
     <!-- Testing -->

--- a/src/LightResults.Extensions.EntityFrameworkCore/ResultDbContext.cs
+++ b/src/LightResults.Extensions.EntityFrameworkCore/ResultDbContext.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using LightResults;
 
 namespace LightResults.Extensions.EntityFrameworkCore;
 

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.Action.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.Action.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandler
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.Func.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.Func.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandler
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.Task.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.Task.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandler
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.TaskFunc.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.TaskFunc.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandler
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.ValueTask.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.ValueTask.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandler
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.ValueTaskFunc.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.ValueTaskFunc.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandler
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 /// <summary>Provides extension methods for handling exceptions using the <see cref="Result"/> type.</summary>
 public static partial class ExceptionHandler

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.Action.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.Action.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandlingExtensions
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.Func.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.Func.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandlingExtensions
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.Task.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.Task.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandlingExtensions
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.TaskFunc.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.TaskFunc.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandlingExtensions
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.ValueTask.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.ValueTask.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandlingExtensions
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.ValueTaskFunc.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.ValueTaskFunc.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 public static partial class ExceptionHandlingExtensions
 {

--- a/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/ExceptionHandlingExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace LightResults.Extensions.ExceptionHandling;
+namespace LightResults.Extensions.ExceptionHandling;
 
 /// <summary>Provides extension methods for handling exceptions using the <see cref="Result"/> type.</summary>
 public static partial class ExceptionHandlingExtensions;

--- a/src/LightResults.Extensions.ExceptionHandling/LightResults.Extensions.ExceptionHandling.csproj
+++ b/src/LightResults.Extensions.ExceptionHandling/LightResults.Extensions.ExceptionHandling.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <!-- Compilation -->
     <PropertyGroup>
@@ -54,9 +54,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\Icon.png" Pack="true" PackagePath="\" Visible="false"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\Icon.png" Pack="true" PackagePath="" Visible="false"/>
     </ItemGroup>
 
     <!-- Testing -->

--- a/src/LightResults.Extensions.Json/LightResults.Extensions.Json.csproj
+++ b/src/LightResults.Extensions.Json/LightResults.Extensions.Json.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <!-- Compilation -->
     <PropertyGroup>
@@ -53,9 +53,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\Icon.png" Pack="true" PackagePath="\" Visible="false"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\Icon.png" Pack="true" PackagePath="" Visible="false"/>
     </ItemGroup>
 
     <!-- Testing -->

--- a/src/LightResults.Extensions.Json/ResultJsonConverter.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/LightResults.Extensions.Json/ResultJsonConverterFactory.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverterFactory.cs
@@ -1,4 +1,4 @@
-﻿#if NET7_0_OR_GREATER
+#if NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Text.Json;

--- a/src/LightResults.Extensions.Json/ResultJsonConverter`1.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverter`1.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/LightResults.Extensions.Operations/EnumerableExtensions.cs
+++ b/src/LightResults.Extensions.Operations/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace LightResults.Extensions.Operations;
 

--- a/src/LightResults.Extensions.Operations/LightResults.Extensions.Operations.csproj
+++ b/src/LightResults.Extensions.Operations/LightResults.Extensions.Operations.csproj
@@ -53,9 +53,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" Visible="false"/>
-        <None Include="..\..\Icon.png" Pack="true" PackagePath="\" Visible="false"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" Visible="false"/>
+        <None Include="..\..\Icon.png" Pack="true" PackagePath="" Visible="false"/>
     </ItemGroup>
 
     <!-- Testing -->


### PR DESCRIPTION
## Summary
- fix README and license packaging paths
- add LightResults using directive
- enforce consistent encoding via .gitattributes and .editorconfig
- remove byte order marks from source files

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_687d3e759d848328acc2c2c1abe6d5bb