### PR TITLE
Reference ExceptionHandling project in OpenAI library

### DIFF
--- a/src/LightResults.Extensions.OpenAI/LightResults.Extensions.OpenAI.csproj
+++ b/src/LightResults.Extensions.OpenAI/LightResults.Extensions.OpenAI.csproj
@@ -18,9 +18,12 @@
     <!-- References -->
     <ItemGroup>
         <PackageReference Include="LightResults" Version="10.0.0"/>
-        <PackageReference Include="LightResults.Extensions.ExceptionHandling" Version="10.0.0"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="OpenAI" Version="2.2.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\LightResults.Extensions.ExceptionHandling\LightResults.Extensions.ExceptionHandling.csproj" />
     </ItemGroup>
 
     <!-- Output -->


### PR DESCRIPTION
## Summary
- switch the OpenAI project to reference the local ExceptionHandling project instead of the published package

## Testing
- dotnet build --configuration Release *(fails: current SDK does not support net10.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e668d44c8328b36d27661101137c)