### PR TITLE
Remove legacy NET preprocessor directives

### DIFF
--- a/src/LightResults.Extensions.ExceptionHandling/EnumerableExtensions.cs
+++ b/src/LightResults.Extensions.ExceptionHandling/EnumerableExtensions.cs
@@ -1,27 +1,14 @@
-﻿#if NET7_0_OR_GREATER
 using System.Diagnostics;
-#endif
-#if NET6_0_OR_GREATER
 using System.Runtime.CompilerServices;
-#endif
 
 namespace LightResults.Extensions.ExceptionHandling;
 
-
-#if NET6_0_OR_GREATER
 /// <summary>
 /// Provides extension methods for <see cref="IEnumerable{T}"/> and <see cref="IAsyncEnumerable{T}"/>
 /// that wrap enumeration in <see cref="Result{T}"/> to capture exceptions as failed results.
 /// </summary>
-#else
-/// <summary>
-/// Provides extension methods for <see cref="IEnumerable{T}"/>
-/// that wrap enumeration in <see cref="Result{T}"/> to capture exceptions as failed results.
-/// </summary>
-#endif
 public static class EnumerableExtensions
 {
-#if NET7_0_OR_GREATER
     /// <summary>
     /// Enumerates the elements of the sequence, wrapping each element in a <see cref="Result{T}"/>.
     /// If an exception occurs during enumeration, yields a failed <see cref="Result{T}"/> containing the exception.
@@ -34,28 +21,9 @@ public static class EnumerableExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
     /// <exception cref="UnreachableException">The enumerator could not be obtained from <paramref name="source"/>.</exception>
-#else
-    /// <summary>
-    /// Enumerates the elements of the sequence, wrapping each element in a <see cref="Result{T}"/>.
-    /// If an exception occurs during enumeration, yields a failed <see cref="Result{T}"/> containing the exception.
-    /// </summary>
-    /// <typeparam name="T">The type of the elements of <paramref name="source"/>.</typeparam>
-    /// <param name="source">The sequence to enumerate.</param>
-    /// <returns>
-    /// An <see cref="IEnumerable{T}"/> of <see cref="Result{T}"/> objects, where each successful result contains
-    /// an item from <paramref name="source"/>, or a failure result contains the exception thrown during enumeration.
-    /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
-    /// <exception cref="InvalidOperationException">The enumerator could not be obtained from <paramref name="source"/>.</exception>
-#endif
     public static IEnumerable<Result<T>> AsEnumerableResult<T>(this IEnumerable<T> source)
     {
-#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(source);
-#else
-        if (source is null)
-            throw new ArgumentNullException(nameof(source));
-#endif
 
         Exception? exception = null;
 
@@ -77,11 +45,7 @@ public static class EnumerableExtensions
         }
 
         if (enumerator is null)
-#if NET7_0_OR_GREATER
             throw new UnreachableException("The enumerator was unexpectedly null.");
-#else
-            throw new InvalidOperationException("The enumerator was unexpectedly null.");
-#endif
 
         var hasMoreItems = true;
 
@@ -129,8 +93,6 @@ public static class EnumerableExtensions
         }
     }
 
-#if NET6_0_OR_GREATER
-#if NET7_0_OR_GREATER
     /// <summary>
     /// Asynchronously enumerates the elements of the sequence, wrapping each element in a <see cref="Result{T}"/>.
     /// If an exception occurs during asynchronous enumeration, yields a failed <see cref="Result{T}"/> containing the exception.
@@ -144,21 +106,6 @@ public static class EnumerableExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
     /// <exception cref="UnreachableException">The asynchronous enumerator could not be obtained from <paramref name="source"/>.</exception>
-#else
-    /// <summary>
-    /// Asynchronously enumerates the elements of the sequence, wrapping each element in a <see cref="Result{T}"/>.
-    /// If an exception occurs during asynchronous enumeration, yields a failed <see cref="Result{T}"/> containing the exception.
-    /// </summary>
-    /// <typeparam name="T">The type of the elements of <paramref name="source"/>.</typeparam>
-    /// <param name="source">The asynchronous sequence to enumerate.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous enumeration.</param>
-    /// <returns>
-    /// An <see cref="IAsyncEnumerable{T}"/> of <see cref="Result{T}"/> objects, where each successful result contains
-    /// an item from <paramref name="source"/>, or a failure result contains the exception thrown during asynchronous enumeration.
-    /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
-    /// <exception cref="InvalidOperationException">The asynchronous enumerator could not be obtained from <paramref name="source"/>.</exception>
-#endif
     public static async IAsyncEnumerable<Result<T>> AsAsyncEnumerableResult<T>(
         this IAsyncEnumerable<T> source,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
@@ -188,11 +135,7 @@ public static class EnumerableExtensions
         }
 
         if (enumerator is null)
-#if NET7_0_OR_GREATER
             throw new UnreachableException("The enumerator was unexpectedly null.");
-#else
-            throw new InvalidOperationException("The enumerator was unexpectedly null.");
-#endif
 
         var hasMoreItems = true;
 
@@ -242,5 +185,4 @@ public static class EnumerableExtensions
             yield return Result.Success(current);
         }
     }
-#endif
 }

--- a/src/LightResults.Extensions.Json/ResultJsonConverterFactory.cs
+++ b/src/LightResults.Extensions.Json/ResultJsonConverterFactory.cs
@@ -1,16 +1,12 @@
-#if NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LightResults.Extensions.Json;
 
 /// <summary>JsonConverterFactory for converting Result types to and from JSON.</summary>
-#if NET7_0_OR_GREATER
 [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
-[RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can\'t validate that the requirements of those annotations are met.")]
-#endif
+[RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
 public class ResultJsonConverterFactory : JsonConverterFactory
 {
     /// <inheritdoc/>

--- a/src/LightResults.Extensions.Operations/EnumerableExtensions.cs
+++ b/src/LightResults.Extensions.Operations/EnumerableExtensions.cs
@@ -14,12 +14,7 @@ public static class EnumerableExtensions
     /// <remarks>This will enumerate the <paramref name="results"/>.</remarks>
     public static Result Collect(this IEnumerable<Result> results)
     {
-#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(results);
-#else
-        if (results is null)
-            throw new ArgumentNullException(nameof(results));
-#endif
 
         List<IError>? errors = null;
         
@@ -45,12 +40,7 @@ public static class EnumerableExtensions
     /// </returns>
     public static Result Collect(this IReadOnlyList<Result> results)
     {
-#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(results);
-#else
-        if (results is null)
-            throw new ArgumentNullException(nameof(results));
-#endif
 
         List<IError>? errors = null;
         
@@ -78,12 +68,7 @@ public static class EnumerableExtensions
     /// <remarks>This will enumerate the <paramref name="results"/>.</remarks>
     public static Result<IReadOnlyList<TValue>> Collect<TValue>(this IEnumerable<Result<TValue>> results)
     {
-#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(results);
-#else
-        if (results is null)
-            throw new ArgumentNullException(nameof(results));
-#endif
 
         List<TValue>? values = null;
         List<IError>? errors = null;
@@ -123,12 +108,7 @@ public static class EnumerableExtensions
     /// </returns>
     public static Result<IReadOnlyList<TValue>> Collect<TValue>(this IReadOnlyList<Result<TValue>> results)
     {
-#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(results);
-#else
-        if (results is null)
-            throw new ArgumentNullException(nameof(results));
-#endif
 
         List<TValue>? values = null;
         List<IError>? errors = null;

--- a/tests/LightResults.Extensions.Tests/ExceptionHandling/EnumerableExtensionsTests.cs
+++ b/tests/LightResults.Extensions.Tests/ExceptionHandling/EnumerableExtensionsTests.cs
@@ -98,7 +98,6 @@ public sealed class EnumerableExtensionsTests
         results.ShouldBe(new[] { 2, 4, 6, 8, 10 });
     }
 
-#if NET6_0_OR_GREATER
     [Fact]
     public async Task AsAsyncEnumerableResult_ValidSequence_ShouldReturnAllItemsAsSuccessResults()
     {
@@ -148,8 +147,6 @@ public sealed class EnumerableExtensionsTests
             yield return item;
         }
     }
-
-#endif
 
     private class ExceptionThrowingEnumerable<T> : IEnumerable<T>
     {


### PR DESCRIPTION
## Summary
- remove NET6/NET7 conditional compilation guards now that projects target .NET 8+
- apply runtime trimming annotations and .NET 8 code paths unconditionally
- enable async enumerable tests without framework guards

## Testing
- dotnet test --configuration Release --framework net10.0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d7174d5083289384393e3c964e95)