### PR TITLE
Update OpenAI extensions for 2.5.0

### DIFF
--- a/src/LightResults.Extensions.OpenAI/AssistantClientExtensions.cs
+++ b/src/LightResults.Extensions.OpenAI/AssistantClientExtensions.cs
@@ -882,29 +882,6 @@ public static class AssistantClientExtensions
         return funcResult.AsFailure<IAsyncEnumerable<Result<Assistant>>>();
     }
 
-    /// <summary>Attempts to asynchronously retrieve assistants with continuation token and wraps the result as an asynchronous enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an asynchronous enumerable of <see cref="Result{Assistant}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IAsyncEnumerable<Result<Assistant>>> TryGetAssistantsAsync(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, AsyncCollectionResult<Assistant>> func = client.GetAssistantsAsync;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsAsyncEnumerableResult(cancellationToken));
-
-        return funcResult.AsFailure<IAsyncEnumerable<Result<Assistant>>>();
-    }
-
     /// <summary>Attempts to synchronously retrieve assistants and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
     /// <param name="client">The assistant client instance.</param>
     /// <param name="options">Assistant collection options.</param>
@@ -922,29 +899,6 @@ public static class AssistantClientExtensions
         Func<AssistantCollectionOptions?, CancellationToken, CollectionResult<Assistant>> func = client.GetAssistants;
 
         var funcResult = func.Try(options, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsEnumerableResult());
-
-        return funcResult.AsFailure<IEnumerable<Result<Assistant>>>();
-    }
-
-    /// <summary>Attempts to synchronously retrieve assistants with continuation token and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an enumerable of <see cref="Result{Assistant}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IEnumerable<Result<Assistant>>> TryGetAssistants(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, CollectionResult<Assistant>> func = client.GetAssistants;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
         if (funcResult.IsSuccess(out var collectionResult))
             return Result.Success(collectionResult.AsEnumerableResult());
 
@@ -976,29 +930,6 @@ public static class AssistantClientExtensions
         return funcResult.AsFailure<IAsyncEnumerable<Result<ThreadMessage>>>();
     }
 
-    /// <summary>Attempts to asynchronously retrieve messages with continuation token and wraps the result as an asynchronous enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an asynchronous enumerable of <see cref="Result{ThreadMessage}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IAsyncEnumerable<Result<ThreadMessage>>> TryGetMessagesAsync(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, AsyncCollectionResult<ThreadMessage>> func = client.GetMessagesAsync;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsAsyncEnumerableResult(cancellationToken));
-
-        return funcResult.AsFailure<IAsyncEnumerable<Result<ThreadMessage>>>();
-    }
-
     /// <summary>Attempts to synchronously retrieve messages and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
     /// <param name="client">The assistant client instance.</param>
     /// <param name="threadId">The thread ID to retrieve messages from.</param>
@@ -1018,29 +949,6 @@ public static class AssistantClientExtensions
         Func<string, MessageCollectionOptions?, CancellationToken, CollectionResult<ThreadMessage>> func = client.GetMessages;
 
         var funcResult = func.Try(threadId, options, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsEnumerableResult());
-
-        return funcResult.AsFailure<IEnumerable<Result<ThreadMessage>>>();
-    }
-
-    /// <summary>Attempts to synchronously retrieve messages with continuation token and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an enumerable of <see cref="Result{ThreadMessage}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IEnumerable<Result<ThreadMessage>>> TryGetMessages(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, CollectionResult<ThreadMessage>> func = client.GetMessages;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
         if (funcResult.IsSuccess(out var collectionResult))
             return Result.Success(collectionResult.AsEnumerableResult());
 
@@ -1117,29 +1025,6 @@ public static class AssistantClientExtensions
         return funcResult.AsFailure<IAsyncEnumerable<Result<ThreadRun>>>();
     }
 
-    /// <summary>Attempts to asynchronously retrieve runs with continuation token and wraps the result as an asynchronous enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an asynchronous enumerable of <see cref="Result{ThreadRun}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IAsyncEnumerable<Result<ThreadRun>>> TryGetRunsAsync(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, AsyncCollectionResult<ThreadRun>> func = client.GetRunsAsync;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsAsyncEnumerableResult(cancellationToken));
-
-        return funcResult.AsFailure<IAsyncEnumerable<Result<ThreadRun>>>();
-    }
-
     /// <summary>Attempts to synchronously retrieve runs and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
     /// <param name="client">The assistant client instance.</param>
     /// <param name="threadId">The thread ID to retrieve runs from.</param>
@@ -1159,29 +1044,6 @@ public static class AssistantClientExtensions
         Func<string, RunCollectionOptions?, CancellationToken, CollectionResult<ThreadRun>> func = client.GetRuns;
 
         var funcResult = func.Try(threadId, options, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsEnumerableResult());
-
-        return funcResult.AsFailure<IEnumerable<Result<ThreadRun>>>();
-    }
-
-    /// <summary>Attempts to synchronously retrieve runs with continuation token and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an enumerable of <see cref="Result{ThreadRun}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IEnumerable<Result<ThreadRun>>> TryGetRuns(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, CollectionResult<ThreadRun>> func = client.GetRuns;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
         if (funcResult.IsSuccess(out var collectionResult))
             return Result.Success(collectionResult.AsEnumerableResult());
 
@@ -1269,29 +1131,6 @@ public static class AssistantClientExtensions
         return funcResult.AsFailure<IAsyncEnumerable<Result<RunStep>>>();
     }
 
-    /// <summary>Attempts to asynchronously retrieve run steps with continuation token and wraps the result as an asynchronous enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an asynchronous enumerable of <see cref="Result{RunStep}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IAsyncEnumerable<Result<RunStep>>> TryGetRunStepsAsync(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, AsyncCollectionResult<RunStep>> func = client.GetRunStepsAsync;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsAsyncEnumerableResult(cancellationToken));
-
-        return funcResult.AsFailure<IAsyncEnumerable<Result<RunStep>>>();
-    }
-
     /// <summary>Attempts to synchronously retrieve run steps and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
     /// <param name="client">The assistant client instance.</param>
     /// <param name="threadId">The thread ID containing the run.</param>
@@ -1313,29 +1152,6 @@ public static class AssistantClientExtensions
         Func<string, string, RunStepCollectionOptions?, CancellationToken, CollectionResult<RunStep>> func = client.GetRunSteps;
 
         var funcResult = func.Try(threadId, runId, options, cancellationToken);
-        if (funcResult.IsSuccess(out var collectionResult))
-            return Result.Success(collectionResult.AsEnumerableResult());
-
-        return funcResult.AsFailure<IEnumerable<Result<RunStep>>>();
-    }
-
-    /// <summary>Attempts to synchronously retrieve run steps with continuation token and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
-    /// <param name="client">The assistant client instance.</param>
-    /// <param name="firstPageToken">The continuation token for the first page.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A <see cref="Result{T}"/> containing an enumerable of <see cref="Result{RunStep}"/>.</returns>
-    [Experimental("OPENAI001")]
-    public static Result<IEnumerable<Result<RunStep>>> TryGetRunSteps(
-        this AssistantClient client,
-        ContinuationToken firstPageToken,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(client);
-
-        Func<ContinuationToken, CancellationToken, CollectionResult<RunStep>> func = client.GetRunSteps;
-
-        var funcResult = func.Try(firstPageToken, cancellationToken);
         if (funcResult.IsSuccess(out var collectionResult))
             return Result.Success(collectionResult.AsEnumerableResult());
 

--- a/src/LightResults.Extensions.OpenAI/ChatClientExtensions.cs
+++ b/src/LightResults.Extensions.OpenAI/ChatClientExtensions.cs
@@ -228,6 +228,56 @@ public static class ChatClientExtensions
         return funcResult.AsFailure<ChatCompletion>();
     }
 
+    /// <summary>Attempts to asynchronously update chat completion metadata and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The ID of the chat completion to update.</param>
+    /// <param name="metadata">The metadata values to apply.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation, containing a <see cref="Result{ChatCompletion}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static async Task<Result<ChatCompletion>> TryUpdateChatCompletionAsync(
+        this ChatClient client,
+        string completionId,
+        IDictionary<string, string?> metadata,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, IDictionary<string, string?>, CancellationToken, Task<ClientResult<ChatCompletion>>> func = client.UpdateChatCompletionAsync;
+
+        var funcResult = await func.TryAsync(completionId, metadata, cancellationToken).ConfigureAwait(false);
+        if (funcResult.IsSuccess(out var clientResult))
+            return Result.Success(clientResult.Value);
+
+        return funcResult.AsFailure<ChatCompletion>();
+    }
+
+    /// <summary>Attempts to synchronously update chat completion metadata and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The ID of the chat completion to update.</param>
+    /// <param name="metadata">The metadata values to apply.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Result{ChatCompletion}"/> representing the outcome.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<ChatCompletion> TryUpdateChatCompletion(
+        this ChatClient client,
+        string completionId,
+        IDictionary<string, string?> metadata,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, IDictionary<string, string?>, CancellationToken, ClientResult<ChatCompletion>> func = client.UpdateChatCompletion;
+
+        var funcResult = func.Try(completionId, metadata, cancellationToken);
+        if (funcResult.IsSuccess(out var clientResult))
+            return Result.Success(clientResult.Value);
+
+        return funcResult.AsFailure<ChatCompletion>();
+    }
+
     /// <summary>Attempts to asynchronously delete a specific chat completion by its ID and wraps the result in a <see cref="Result{T}"/>.</summary>
     /// <param name="client">The chat client instance.</param>
     /// <param name="completionId">The ID of the chat completion to delete.</param>
@@ -270,6 +320,104 @@ public static class ChatClientExtensions
             return Result.Success(clientResult.Value);
 
         return funcResult.AsFailure<ChatCompletionDeletionResult>();
+    }
+
+    /// <summary>Attempts to asynchronously retrieve chat completions and wraps the result as an asynchronous enumerable of <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="options">Chat completion collection options.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing an asynchronous enumerable of <see cref="Result{ChatCompletion}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<IAsyncEnumerable<Result<ChatCompletion>>> TryGetChatCompletionsAsync(
+        this ChatClient client,
+        ChatCompletionCollectionOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<ChatCompletionCollectionOptions?, CancellationToken, AsyncCollectionResult<ChatCompletion>> func = client.GetChatCompletionsAsync;
+
+        var funcResult = func.Try(options, cancellationToken);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult.AsAsyncEnumerableResult(cancellationToken));
+
+        return funcResult.AsFailure<IAsyncEnumerable<Result<ChatCompletion>>>();
+    }
+
+    /// <summary>Attempts to synchronously retrieve chat completions and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="options">Chat completion collection options.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing an enumerable of <see cref="Result{ChatCompletion}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<IEnumerable<Result<ChatCompletion>>> TryGetChatCompletions(
+        this ChatClient client,
+        ChatCompletionCollectionOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<ChatCompletionCollectionOptions?, CancellationToken, CollectionResult<ChatCompletion>> func = client.GetChatCompletions;
+
+        var funcResult = func.Try(options, cancellationToken);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult.AsEnumerableResult());
+
+        return funcResult.AsFailure<IEnumerable<Result<ChatCompletion>>>();
+    }
+
+    /// <summary>Attempts to asynchronously retrieve chat completion messages and wraps the result as an asynchronous enumerable of <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The completion identifier.</param>
+    /// <param name="options">Chat completion message collection options.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing an asynchronous enumerable of <see cref="Result{ChatCompletionMessageListDatum}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<IAsyncEnumerable<Result<ChatCompletionMessageListDatum>>> TryGetChatCompletionMessagesAsync(
+        this ChatClient client,
+        string completionId,
+        ChatCompletionMessageCollectionOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, ChatCompletionMessageCollectionOptions?, CancellationToken, AsyncCollectionResult<ChatCompletionMessageListDatum>> func =
+            client.GetChatCompletionMessagesAsync;
+
+        var funcResult = func.Try(completionId, options, cancellationToken);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult.AsAsyncEnumerableResult(cancellationToken));
+
+        return funcResult.AsFailure<IAsyncEnumerable<Result<ChatCompletionMessageListDatum>>>();
+    }
+
+    /// <summary>Attempts to synchronously retrieve chat completion messages and wraps the result as an enumerable of <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The completion identifier.</param>
+    /// <param name="options">Chat completion message collection options.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing an enumerable of <see cref="Result{ChatCompletionMessageListDatum}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<IEnumerable<Result<ChatCompletionMessageListDatum>>> TryGetChatCompletionMessages(
+        this ChatClient client,
+        string completionId,
+        ChatCompletionMessageCollectionOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, ChatCompletionMessageCollectionOptions?, CancellationToken, CollectionResult<ChatCompletionMessageListDatum>> func =
+            client.GetChatCompletionMessages;
+
+        var funcResult = func.Try(completionId, options, cancellationToken);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult.AsEnumerableResult());
+
+        return funcResult.AsFailure<IEnumerable<Result<ChatCompletionMessageListDatum>>>();
     }
 
     /// <summary>Attempts to complete a chat asynchronously and wraps the result in a <see cref="Result{T}"/>.</summary>
@@ -382,5 +530,175 @@ public static class ChatClientExtensions
             return Result.Success(clientResult);
 
         return funcResult.AsFailure<ClientResult>();
+    }
+
+    /// <summary>Attempts to asynchronously update chat completion metadata using request content and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The ID of the chat completion to update.</param>
+    /// <param name="content">The binary content payload.</param>
+    /// <param name="options">Optional request options.</param>
+    /// <returns>A task representing the asynchronous operation, containing a <see cref="Result{ClientResult}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static async Task<Result<ClientResult>> TryUpdateChatCompletionAsync(
+        this ChatClient client,
+        string completionId,
+        BinaryContent content,
+        RequestOptions? options = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, BinaryContent, RequestOptions?, Task<ClientResult>> func = client.UpdateChatCompletionAsync;
+
+        var funcResult = await func.TryAsync(completionId, content, options).ConfigureAwait(false);
+        if (funcResult.IsSuccess(out var clientResult))
+            return Result.Success(clientResult);
+
+        return funcResult.AsFailure<ClientResult>();
+    }
+
+    /// <summary>Attempts to synchronously update chat completion metadata using request content and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The ID of the chat completion to update.</param>
+    /// <param name="content">The binary content payload.</param>
+    /// <param name="options">Optional request options.</param>
+    /// <returns>A <see cref="Result{ClientResult}"/> representing the outcome.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<ClientResult> TryUpdateChatCompletion(
+        this ChatClient client,
+        string completionId,
+        BinaryContent content,
+        RequestOptions? options = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, BinaryContent, RequestOptions?, ClientResult> func = client.UpdateChatCompletion;
+
+        var funcResult = func.Try(completionId, content, options);
+        if (funcResult.IsSuccess(out var clientResult))
+            return Result.Success(clientResult);
+
+        return funcResult.AsFailure<ClientResult>();
+    }
+
+    /// <summary>Attempts to asynchronously retrieve chat completions with pagination parameters and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="after">The pagination cursor for subsequent results.</param>
+    /// <param name="limit">The maximum number of items to return.</param>
+    /// <param name="order">The sorting order.</param>
+    /// <param name="metadata">Optional metadata filters.</param>
+    /// <param name="model">The model filter.</param>
+    /// <param name="options">Request options.</param>
+    /// <returns>A task representing the asynchronous operation, containing a <see cref="Result{AsyncCollectionResult}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static async Task<Result<AsyncCollectionResult>> TryGetChatCompletionsAsync(
+        this ChatClient client,
+        string after,
+        int? limit,
+        string order,
+        IDictionary<string, string?>? metadata,
+        string model,
+        RequestOptions options
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, int?, string, IDictionary<string, string?>?, string, RequestOptions, AsyncCollectionResult> func = client.GetChatCompletionsAsync;
+
+        var funcResult = await Task.Run(() => func.Try(after, limit, order, metadata, model, options)).ConfigureAwait(false);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult);
+
+        return funcResult.AsFailure<AsyncCollectionResult>();
+    }
+
+    /// <summary>Attempts to synchronously retrieve chat completions with pagination parameters and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="after">The pagination cursor for subsequent results.</param>
+    /// <param name="limit">The maximum number of items to return.</param>
+    /// <param name="order">The sorting order.</param>
+    /// <param name="metadata">Optional metadata filters.</param>
+    /// <param name="model">The model filter.</param>
+    /// <param name="options">Request options.</param>
+    /// <returns>A <see cref="Result{CollectionResult}"/> representing the outcome.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<CollectionResult> TryGetChatCompletions(
+        this ChatClient client,
+        string after,
+        int? limit,
+        string order,
+        IDictionary<string, string?>? metadata,
+        string model,
+        RequestOptions options
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, int?, string, IDictionary<string, string?>?, string, RequestOptions, CollectionResult> func = client.GetChatCompletions;
+
+        var funcResult = func.Try(after, limit, order, metadata, model, options);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult);
+
+        return funcResult.AsFailure<CollectionResult>();
+    }
+
+    /// <summary>Attempts to asynchronously retrieve chat completion messages with pagination parameters and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The completion identifier.</param>
+    /// <param name="after">The pagination cursor for subsequent results.</param>
+    /// <param name="limit">The maximum number of items to return.</param>
+    /// <param name="order">The sorting order.</param>
+    /// <param name="options">Request options.</param>
+    /// <returns>A task representing the asynchronous operation, containing a <see cref="Result{AsyncCollectionResult}"/>.</returns>
+    [Experimental("OPENAI001")]
+    public static async Task<Result<AsyncCollectionResult>> TryGetChatCompletionMessagesAsync(
+        this ChatClient client,
+        string completionId,
+        string after,
+        int? limit,
+        string order,
+        RequestOptions options
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, string, int?, string, RequestOptions, AsyncCollectionResult> func = client.GetChatCompletionMessagesAsync;
+
+        var funcResult = await Task.Run(() => func.Try(completionId, after, limit, order, options)).ConfigureAwait(false);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult);
+
+        return funcResult.AsFailure<AsyncCollectionResult>();
+    }
+
+    /// <summary>Attempts to synchronously retrieve chat completion messages with pagination parameters and wraps the result in a <see cref="Result{T}"/>.</summary>
+    /// <param name="client">The chat client instance.</param>
+    /// <param name="completionId">The completion identifier.</param>
+    /// <param name="after">The pagination cursor for subsequent results.</param>
+    /// <param name="limit">The maximum number of items to return.</param>
+    /// <param name="order">The sorting order.</param>
+    /// <param name="options">Request options.</param>
+    /// <returns>A <see cref="Result{CollectionResult}"/> representing the outcome.</returns>
+    [Experimental("OPENAI001")]
+    public static Result<CollectionResult> TryGetChatCompletionMessages(
+        this ChatClient client,
+        string completionId,
+        string after,
+        int? limit,
+        string order,
+        RequestOptions options
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Func<string, string, int?, string, RequestOptions, CollectionResult> func = client.GetChatCompletionMessages;
+
+        var funcResult = func.Try(completionId, after, limit, order, options);
+        if (funcResult.IsSuccess(out var collectionResult))
+            return Result.Success(collectionResult);
+
+        return funcResult.AsFailure<CollectionResult>();
     }
 }

--- a/src/LightResults.Extensions.OpenAI/LightResults.Extensions.OpenAI.csproj
+++ b/src/LightResults.Extensions.OpenAI/LightResults.Extensions.OpenAI.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
         <PackageReference Include="LightResults" Version="10.0.0"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-        <PackageReference Include="OpenAI" Version="2.4.0" />
+        <PackageReference Include="OpenAI" Version="2.5.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- upgrade the OpenAI dependency to version 2.5.0
- drop deprecated continuation token paging helpers and align assistant extensions with current signatures
- add result-based wrappers for new chat completion update and listing APIs to maintain full surface coverage

## Testing
- dotnet build --configuration Release --no-restore

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dcf41b4c832899eeac164a0751fc)