### PR TITLE
Upgrade OpenAI package to 2.7.0

### DIFF
--- a/src/LightResults.Extensions.OpenAI/LightResults.Extensions.OpenAI.csproj
+++ b/src/LightResults.Extensions.OpenAI/LightResults.Extensions.OpenAI.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
         <PackageReference Include="LightResults" Version="10.0.0"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-        <PackageReference Include="OpenAI" Version="2.6.0" />
+        <PackageReference Include="OpenAI" Version="2.7.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- bump the OpenAI client dependency to version 2.7.0 for the OpenAI extensions package

## Testing
- dotnet build --configuration Release --no-restore
- dotnet test --configuration Release --no-build --verbosity normal --framework net10.0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e12264e483289044c64fc9352682)